### PR TITLE
fix: prevent background scrolling while SearchOverlay is visible

### DIFF
--- a/src/components/NavBar/SearchOverlay.vue
+++ b/src/components/NavBar/SearchOverlay.vue
@@ -68,6 +68,16 @@ const keyword = ref('')
 const results = ref<any[]>([])
 const inputRef = ref<HTMLInputElement | null>(null)
 let timer: any = null
+let previousBodyOverflow = ''
+
+const lockBodyScroll = () => {
+  previousBodyOverflow = document.body.style.overflow
+  document.body.style.overflow = 'hidden'
+}
+
+const unlockBodyScroll = () => {
+  document.body.style.overflow = previousBodyOverflow
+}
 
 const currentLocale = computed(() => locale.value)
 
@@ -136,12 +146,15 @@ watch(
   () => props.visible,
   (newVal) => {
     if (newVal) {
+      lockBodyScroll()
       nextTick(() => inputRef.value?.focus())
     } else {
+      unlockBodyScroll()
       keyword.value = ''
       results.value = []
     }
   },
+  { immediate: true },
 )
 
 watch(currentLocale, () => {
@@ -153,6 +166,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  unlockBodyScroll()
   window.removeEventListener('keydown', onKeyDown)
   clearTimeout(timer)
 })


### PR DESCRIPTION
### Motivation
- Prevent mouse wheel and other scroll actions from scrolling the page behind the `SearchOverlay` when the overlay is open.
- Ensure the overlay correctly locks scroll also when the component is initially rendered in a visible state and that no scroll lock side-effect remains after the component is unmounted.

### Description
- Add `previousBodyOverflow` state and two helpers `lockBodyScroll` / `unlockBodyScroll` to save and restore `document.body.style.overflow`.
- Call `lockBodyScroll()` when `props.visible` becomes `true` and `unlockBodyScroll()` when it becomes `false`.
- Make the `visible` watcher `immediate: true` so initial visibility applies the scroll lock on mount.
- Call `unlockBodyScroll()` in `onUnmounted` to ensure the body overflow is restored if the component is destroyed while locked.

### Testing
- Ran `pnpm -s type-check`; the run failed due to an existing TypeScript config issue (`tsconfig.json` `baseUrl` deprecation error) which is unrelated to this change and prevents a clean type-check run in CI locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c630de03f08333a3cd05b9d4af8ad0)