### PR TITLE
fix: remove persistent outer rounded border around pages

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,14 +1,7 @@
 @import './variables.css';
 
-html,
-body,
-#app {
+body {
   margin: 0;
-  padding: 0;
-  border: 0;
-  border-radius: 0;
-  min-height: 100%;
-  background: var(--bg-white);
 }
 
 /* 让锚点跳转时，标题下方留出空间，不被固定导航栏遮住 */

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,5 +1,16 @@
 @import './variables.css';
 
+html,
+body,
+#app {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  min-height: 100%;
+  background: var(--bg-white);
+}
+
 /* 让锚点跳转时，标题下方留出空间，不被固定导航栏遮住 */
 h1[id],
 h2[id],


### PR DESCRIPTION
### Motivation
- The site showed a persistent rounded frame around every page that did not follow the color mode, so a global reset is needed to remove that outer rounded border and let the root background follow theme variables.

### Description
- Add a small global reset block to `src/styles/markdown.css` that clears `margin`, `padding`, `border`, and `border-radius` for `html`, `body`, and `#app`, and sets the root background to `var(--bg-white)` so it follows light/dark mode.

### Testing
- Ran `pnpm -s type-check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7096b081c833386df77e342ca6b29)